### PR TITLE
Changing "python" to "python3" in the startup script

### DIFF
--- a/w3d
+++ b/w3d
@@ -1,1 +1,1 @@
-cd ~/.w3 && python -m http.server 3132
+cd ~/.w3 && python3 -m http.server 3132


### PR DESCRIPTION
Since .w3 uses Python 3's http.server, it would be better to launch it with "python3", since it will always launch the 3.x version, while "python" will default to 2.x on some configurations.

AFAIK, "/usr/bin/python3" symlink is available on most distros.
